### PR TITLE
BugFix: Model.bulkWrite

### DIFF
--- a/src/controller/controller.js
+++ b/src/controller/controller.js
@@ -268,8 +268,9 @@ module.exports = function (ModelName) {
 
         var operations = req.body || [];
 
-        Model
-            .bulkWrite(operations)
+        var bulkWrite = Model.bulkWrite || Model.collection.bulkWrite;
+
+        bulkWrite(operations)
             .then(bulkWriteOpResult => res.send(bulkWriteOpResult))
             .catch(e => res.status(500).send(e));
     }


### PR DESCRIPTION
Change made for bulkWrite feature to work in previous version of Mongoose and MongoDB.

For newer version, Model.bulkWrite suffices.
For older version, Model.collection.bulkWrite must be used.