### PR TITLE
v0.1.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mongoose-rest-query",
-    "version": "0.1.23",
+    "version": "0.1.24",
     "description": "Mongoose",
     "main": "src/index.js",
     "scripts": {},

--- a/src/db-pool.js
+++ b/src/db-pool.js
@@ -10,7 +10,9 @@ module.exports = function() {
         var modelSchemas = require('./config').modelSchemas;
 
         Object.keys(modelSchemas).map(function(item) {
-            db.model(item, modelSchemas[item]);
+            var Model = db.model(item, modelSchemas[item]);
+
+            Model.syncIndexes && Model.syncIndexes();
         });
 
         autoNumber.init(db);


### PR DESCRIPTION
**Feature: SyncIndexes**
- Ensure that mongodb indexes and mongoose indexes are synchronized on each Model initialization

**Reason of PR:**
- Recently I had a bug where a previous unique index without the sparse option was preventing any insertion. 
- Adding sparse option in Mongoose did not sync the index. 
- Rather, upon inspection in NoSQLBooster (collection.getIndexes), I saw that the one with sparse and the one without sparse were both present with different names.
- Consequently, duplication error with null value occurred even when sparse was used.