### PR TITLE
v0.1.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mongoose-rest-query",
-    "version": "0.1.25",
+    "version": "0.1.26",
     "description": "Mongoose",
     "main": "src/index.js",
     "scripts": {},

--- a/src/controller/controller.js
+++ b/src/controller/controller.js
@@ -269,9 +269,9 @@ module.exports = function (ModelName) {
 
         var operations = req.body || [];
 
-        var bulkWrite = Model.bulkWrite || Model.collection.bulkWrite;
+        var ModelOrCollection = Model.bulkWrite ? Model : Model.collection;
 
-        bulkWrite(operations)
+        ModelOrCollection.bulkWrite(operations)
             .then(bulkWriteOpResult => res.send(bulkWriteOpResult))
             .catch(e => res.status(500).send(e));
     }


### PR DESCRIPTION
**Bug:**
Using 
```
var bulkWrite = Model.bulkWrite || Model.collection.bulkWrite;
bulkWrite(operations)
```
was changing 'this' context of Model.bulkWrite and Model.collection.bulkWrite.

**Solution:**
Use
```
var ModelOrCollection = Model.bulkWrite ? Model : Model.collection;
ModelOrCollection.bulkWrite(operations)
```
to prevent 'this' context from changing to global 'this'.

**Alternative solution:**
.bind could've also been used but it entailed more letters. 
Simplicity was chosen.