### PR TITLE
v0.1.30: Pass req in .save and .create fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mongoose-rest-query",
-    "version": "0.1.29",
+    "version": "0.1.30",
     "description": "Mongoose",
     "main": "src/index.js",
     "scripts": {},

--- a/src/controller/controller.js
+++ b/src/controller/controller.js
@@ -59,7 +59,7 @@ module.exports = function (ModelName) {
     var create = function (req, res) {
         var Model = getModel(req);
 
-        Model.create(req.body, function (err, data) {
+        Model.create(req.body, { req }, function (err, data) {
             if (err)
                 res.status(500).send(err);
             else
@@ -113,7 +113,7 @@ module.exports = function (ModelName) {
 
             Object.keys(req.body).forEach(model.markModified.bind(model));
 
-            model.save(function (err, data) {
+            model.save({ req }, function (err, data) {
                 if (err)
                     res.status(500).send(err);
                 else {
@@ -177,7 +177,7 @@ module.exports = function (ModelName) {
             Object.keys(body).forEach(field => model.markModified(field));
 
             let response;
-            try { response = await model.save() }
+            try { response = await model.save({ req }) }
             catch (e) { return res.status(500).send(e) };
 
             if (response instanceof ServerResponse)

--- a/src/controller/controller.sub.child.js
+++ b/src/controller/controller.sub.child.js
@@ -35,7 +35,7 @@ module.exports = function (ModelName, subItemName, childName) {
 
     function save(req, res, initalKeys, keysToReturn) {
 
-        req.model.save(function (err, data) {
+        req.model.save({ req }, function (err, data) {
             if (err)
                 return res.status(500).send(err);
 
@@ -135,7 +135,7 @@ module.exports = function (ModelName, subItemName, childName) {
             child[p] = req.body[p];
         }
 
-        req.model.save(function (err, updatedModel) {
+        req.model.save({ req }, function (err, updatedModel) {
 
             var subitem = updatedModel[subItemName].id(req.params.itemId);
             var child = subitem[childName].id(req.params.childId);
@@ -151,7 +151,7 @@ module.exports = function (ModelName, subItemName, childName) {
             _id: req.params.childId
         });
 
-        req.model.save(function (err, updatedModel) {
+        req.model.save({ req }, function (err, updatedModel) {
             res.send(updatedModel);
         });
 

--- a/src/controller/controller.sub.js
+++ b/src/controller/controller.sub.js
@@ -8,7 +8,7 @@ module.exports = function (ModelName, subItemName) {
     }
 
     function save(req, res, initalItemKeys, keysToReturn) {
-        req.model.save(function (err, data) {
+        req.model.save({ req }, function (err, data) {
             if (err)
                 return res.status(500).send(err);
 
@@ -115,7 +115,7 @@ module.exports = function (ModelName, subItemName) {
             item[p] = req.body[p];
         }
 
-        req.model.save(function (err, data) {
+        req.model.save({ req }, function (err, data) {
             if (err)
                 res.status(500).send(err);
             else


### PR DESCRIPTION
**Description**
Pass req object into .save and .create model functions so that req is accessible in the pre save hooks.

**Motivation**
We want to access properties set in ExpressJS middlewares from pre save hooks.

E.g.
req.user accessed from billdocuments pre save hook:
![image](https://user-images.githubusercontent.com/20681851/165679615-ad593a37-2a0a-4948-9cf3-e12af2ccab93.png)
![image](https://user-images.githubusercontent.com/20681851/165679780-560a413d-ab99-4375-a753-464286751879.png)




